### PR TITLE
Fix game connection issue

### DIFF
--- a/src/screens/HomeScreen.js
+++ b/src/screens/HomeScreen.js
@@ -34,28 +34,32 @@ const HomeScreen = () => {
   };
 
   const handleStartNewGame = () => {
-    if (!currentPlayer) {
+    const effectiveName = currentPlayer || playerName.trim();
+    if (!effectiveName) {
       alert('Ange ditt namn först');
       return;
     }
-    // Set player1 name when starting new game
-    dispatch({ type: 'SET_PLAYER1', payload: currentPlayer });
+    if (!currentPlayer) {
+      dispatch({ type: 'SET_PLAYER', payload: effectiveName });
+    }
+    dispatch({ type: 'SET_PLAYER1', payload: effectiveName });
     navigate('/camera');
   };
 
   const handleJoinGame = () => {
-    if (!currentPlayer) {
+    const effectiveName = currentPlayer || playerName.trim();
+    if (!effectiveName) {
       alert('Ange ditt namn först');
       return;
     }
-    // Use shared parser to handle both hash and search query formats
+    if (!currentPlayer) {
+      dispatch({ type: 'SET_PLAYER', payload: effectiveName });
+    }
     const parsedData = SMSService.parseGameData(window.location.href);
     if (parsedData && parsedData.type === 'HITTA_GAME') {
-      dispatch({ type: 'SET_PLAYER2', payload: currentPlayer });
-      dispatch({
-        type: 'START_GAME',
-        payload: { ...parsedData, isJoining: true },
-      });
+      const joinPayload = { ...parsedData, isJoining: true, playerName: effectiveName };
+      dispatch({ type: 'SET_PLAYER2', payload: effectiveName });
+      dispatch({ type: 'START_GAME', payload: joinPayload });
       navigate('/game');
     } else {
       alert('Inget aktivt spel att gå med i. Kontrollera att du har en giltig spellänk.');

--- a/src/screens/HomeScreen.js
+++ b/src/screens/HomeScreen.js
@@ -8,6 +8,7 @@ const HomeScreen = () => {
   const navigate = useNavigate();
   const [playerName, setPlayerName] = useState(currentPlayer || '');
   const [hasGameLink, setHasGameLink] = useState(false);
+  const [isJoining, setIsJoining] = useState(false);
 
   useEffect(() => {
     // Check for incoming game data from URL (supports hash routing)
@@ -47,9 +48,12 @@ const HomeScreen = () => {
   };
 
   const handleJoinGame = () => {
+    if (isJoining) return;
+    setIsJoining(true);
     const effectiveName = currentPlayer || playerName.trim();
     if (!effectiveName) {
       alert('Ange ditt namn först');
+      setIsJoining(false);
       return;
     }
     if (!currentPlayer) {
@@ -69,8 +73,10 @@ const HomeScreen = () => {
       } catch (e) {
         window.location.hash = '#/game';
       }
+      setIsJoining(false);
     } else {
       alert('Inget aktivt spel att gå med i. Kontrollera att du har en giltig spellänk.');
+      setIsJoining(false);
     }
   };
 
@@ -130,8 +136,8 @@ const HomeScreen = () => {
           <h2>Gå med i spel</h2>
           <p>Du har fått en spellänk! Ange ditt namn för att gå med i spelet.</p>
           
-          <button className="btn btn-primary btn-large" onClick={handleJoinGame}>
-            🎮 Gå med i spel
+          <button className="btn btn-primary btn-large" onClick={handleJoinGame} disabled={isJoining}>
+            {isJoining ? 'Ansluter…' : '🎮 Gå med i spel'}
           </button>
         </div>
       )}

--- a/src/screens/HomeScreen.js
+++ b/src/screens/HomeScreen.js
@@ -10,21 +10,13 @@ const HomeScreen = () => {
   const [hasGameLink, setHasGameLink] = useState(false);
 
   useEffect(() => {
-    // Check for incoming game data from URL parameters
+    // Check for incoming game data from URL (supports hash routing)
     const checkForIncomingGame = () => {
-      const urlParams = new URLSearchParams(window.location.search);
-      const gameData = urlParams.get('game');
-      if (gameData) {
+      const fullUrl = window.location.href;
+      const parsed = SMSService.parseGameData(fullUrl);
+      if (parsed) {
         setHasGameLink(true);
-        try {
-          const parsedData = JSON.parse(decodeURIComponent(gameData));
-          if (parsedData.type === 'HITTA_GAME') {
-            // Don't auto-start game, just show join option
-            console.log('Game link detected:', parsedData);
-          }
-        } catch (error) {
-          console.error('Error parsing game data:', error);
-        }
+        console.log('Game link detected:', parsed);
       } else {
         setHasGameLink(false);
       }
@@ -56,26 +48,15 @@ const HomeScreen = () => {
       alert('Ange ditt namn först');
       return;
     }
-    // Check for incoming game data from URL parameters
-    const urlParams = new URLSearchParams(window.location.search);
-    const gameData = urlParams.get('game');
-    if (gameData) {
-      try {
-        const parsedData = JSON.parse(decodeURIComponent(gameData));
-        if (parsedData.type === 'HITTA_GAME') {
-          // Set player2 name when joining (use current player's name)
-          dispatch({ type: 'SET_PLAYER2', payload: currentPlayer });
-          dispatch({
-            type: 'START_GAME',
-            payload: { ...parsedData, isJoining: true },
-          });
-          // Navigate directly to game to start finding the object
-          navigate('/game');
-        }
-      } catch (error) {
-        console.error('Error parsing game data:', error);
-        alert('Kunde inte läsa speldata från länken');
-      }
+    // Use shared parser to handle both hash and search query formats
+    const parsedData = SMSService.parseGameData(window.location.href);
+    if (parsedData && parsedData.type === 'HITTA_GAME') {
+      dispatch({ type: 'SET_PLAYER2', payload: currentPlayer });
+      dispatch({
+        type: 'START_GAME',
+        payload: { ...parsedData, isJoining: true },
+      });
+      navigate('/game');
     } else {
       alert('Inget aktivt spel att gå med i. Kontrollera att du har en giltig spellänk.');
     }

--- a/src/screens/HomeScreen.js
+++ b/src/screens/HomeScreen.js
@@ -60,7 +60,15 @@ const HomeScreen = () => {
       const joinPayload = { ...parsedData, isJoining: true, playerName: effectiveName };
       dispatch({ type: 'SET_PLAYER2', payload: effectiveName });
       dispatch({ type: 'START_GAME', payload: joinPayload });
-      navigate('/game');
+      try {
+        navigate('/game');
+        // HashRouter fallback
+        if (!window.location.hash.includes('/game')) {
+          window.location.hash = '#/game';
+        }
+      } catch (e) {
+        window.location.hash = '#/game';
+      }
     } else {
       alert('Inget aktivt spel att gå med i. Kontrollera att du har en giltig spellänk.');
     }

--- a/src/services/SMSService.js
+++ b/src/services/SMSService.js
@@ -10,7 +10,9 @@ class SMSService {
       };
 
       const encodedData = encodeURIComponent(JSON.stringify(gameData));
-      const shareUrl = `${window.location.origin}${window.location.pathname}?game=${encodedData}`;
+      // Ensure the URL uses hash routing so the app can read the query
+      const base = `${window.location.origin}${window.location.pathname}`;
+      const shareUrl = `${base}#/?game=${encodedData}`;
       
       const message = `🎯 Hitta! - ${playerName} utmanar dig!\n\nHitta en ${targetObject.objectClass}!\n\nDu har 5 minuter på dig!\n\nSpela här: ${shareUrl}`;
 
@@ -61,7 +63,18 @@ class SMSService {
   parseGameData(url) {
     try {
       const urlObj = new URL(url);
-      const gameParam = urlObj.searchParams.get('game');
+      // First, try standard search params
+      let gameParam = urlObj.searchParams.get('game');
+      // Fallback: parse from hash fragment (for HashRouter), e.g. #/?game=...
+      if (!gameParam && urlObj.hash) {
+        const hash = urlObj.hash.startsWith('#') ? urlObj.hash.slice(1) : urlObj.hash;
+        const queryIndex = hash.indexOf('?');
+        if (queryIndex !== -1) {
+          const hashQuery = hash.slice(queryIndex + 1);
+          const hashParams = new URLSearchParams(hashQuery);
+          gameParam = hashParams.get('game');
+        }
+      }
       if (gameParam) {
         const gameData = JSON.parse(decodeURIComponent(gameParam));
         if (gameData.obj) {


### PR DESCRIPTION
Fix game join links by updating share URL format to use hash-based parameters and enhancing parsing logic to support both old and new link types.

The application uses `HashRouter`, which ignores query parameters in the URL's search part (`?key=value`). To make shared game links functional, the `game` parameter must be placed within the hash fragment (`#/?key=value`). This PR updates the link generation and parsing to correctly handle this.

---
<a href="https://cursor.com/background-agent?bcId=bc-80c851a2-24f6-4cbc-9b72-70cb77750323">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-80c851a2-24f6-4cbc-9b72-70cb77750323">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

