### PR TITLE
Fix CI: add write permissions and remove npm build step

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,32 +3,23 @@ name: Deploy to GitHub Pages
 on:
   push:
     branches: [ main ]
-  pull_request:
-    branches: [ main ]
+
+permissions:
+  contents: write
 
 jobs:
-  build-and-deploy:
+  deploy:
     runs-on: ubuntu-latest
-    
+
     steps:
     - name: Checkout
       uses: actions/checkout@v3
 
-    - name: Setup Node.js
-      uses: actions/setup-node@v3
-      with:
-        node-version: '18'
-        cache: 'npm'
-
-    - name: Install dependencies
-      run: npm ci
-
-    - name: Build
-      run: npm run build
+    - name: Prepare dist
+      run: mkdir dist && cp index.html dist/index.html
 
     - name: Deploy to GitHub Pages
       uses: peaceiris/actions-gh-pages@v3
-      if: github.ref == 'refs/heads/main'
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
-        publish_dir: ./build
+        publish_dir: ./dist


### PR DESCRIPTION
- Add permissions: contents: write to fix the 403 from github-actions[bot]
- Remove npm ci / npm run build steps (no longer needed, app is pure HTML)
- Copy index.html into dist/ and deploy that instead of a React build output

https://claude.ai/code/session_019uRsX5UYsscmMwWq7SqUp4